### PR TITLE
Fix typo on ERC-721 page

### DIFF
--- a/src/content/developers/docs/standards/tokens/erc-721/index.md
+++ b/src/content/developers/docs/standards/tokens/erc-721/index.md
@@ -9,7 +9,7 @@ sidebar: true
 
 **What is a Non-Fungible Token?**
 
-A Non-Fungible Tokens (NFT) is used to identify something or someone in a unique way. This type of Token is perfect to
+A Non-Fungible Token (NFT) is used to identify something or someone in a unique way. This type of Token is perfect to
 be used on platforms that offer collectible items, access keys, lottery tickets, numbered seats for concerts and
 sports matches, etc. This special type of Token has amazing possibilities so it deserves a proper Standard, the ERC-721
 came to solve that!


### PR DESCRIPTION
Fix a simple on the ERC-721 page.

## Description

This commit fixes a plural/singular typo at the beginning of the ERC-721 page.

## Related Issue

<!--- This project accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
